### PR TITLE
Use the namespaced class for Scribunto as the alias was removed

### DIFF
--- a/src/SparqlLua.php
+++ b/src/SparqlLua.php
@@ -6,9 +6,9 @@ namespace ProfessionalWiki\SPARQL;
 
 use InvalidArgumentException;
 use MediaWiki\MediaWikiServices;
-use Scribunto_LuaLibraryBase;
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
 
-class SparqlLua extends Scribunto_LuaLibraryBase {
+class SparqlLua extends LibraryBase {
 
 	public function register(): array {
 		return $this->getEngine()->registerInterface(


### PR DESCRIPTION
From ChatGPT via @LizzAlice

Scribunto_LuaLibraryBase (the old underscore-style global class) was an alias for the namespaced class:

MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase ([gerrit.wikimedia.org][1])

In current Scribunto, the alias line class_alias( LibraryBase::class, 'Scribunto_LuaLibraryBase' ); was removed (along with the autoload entry for Scribunto_LuaLibraryBase). ([gerrit.wikimedia.org][2])

[1]: https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Scribunto/%2B/refs/heads/master/includes/Engines/LuaCommon/LibraryBase.php "includes/Engines/LuaCommon/LibraryBase.php - mediawiki/extensions/Scribunto - Gitiles"
[2]: https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/Scribunto/%2B/a6dbdff2cd2a6d9b879be45f68b00d7770bf9c4d%5E%21/ "Diff - a6dbdff2cd2a6d9b879be45f68b00d7770bf9c4d^! - mediawiki/extensions/Scribunto - Gitiles"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code architecture and library dependencies to improve maintainability and stability. These structural enhancements strengthen the technical foundation for future development while maintaining complete backward compatibility with all existing features and functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->