### PR TITLE
Require MediaWiki 1.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,20 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
+          - mw: 'REL1_43'
             php: '8.1'
             experimental: false
-          - mw: 'REL1_41'
+          - mw: 'REL1_44'
             php: '8.2'
             experimental: false
-          - mw: 'REL1_42'
-            php: '8.3'
-            experimental: false
-          - mw: 'REL1_43'
+          - mw: 'REL1_45'
             php: '8.3'
             experimental: false
           - mw: 'master'
             php: '8.4'
+            experimental: true
+          - mw: 'master'
+            php: '8.5'
             experimental: true
 
     runs-on: ubuntu-latest
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_41'
+          - mw: 'REL1_43'
             php: '8.1'
 
     runs-on: ubuntu-latest
@@ -181,7 +181,7 @@ jobs:
       strategy:
         matrix:
           include:
-            - mw: 'REL1_41'
+            - mw: 'REL1_43'
               php: '8.1'
 
       runs-on: ubuntu-latest
@@ -247,7 +247,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_41'
+          - mw: 'REL1_43'
             php: '8.2'
 
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Lua module examples:
 
 Platform requirements:
 
-* [PHP] 8.1 or later (tested up to 8.3)
-* [MediaWiki] 1.39 or later (tested up to 1.43)
+* [PHP] 8.1 or later (tested up to 8.5)
+* [MediaWiki] 1.43 or later (tested up to 1.45)
 * [Scribunto] and lua
 
 We also recommend installing the [CodeEditor extension]
@@ -125,6 +125,10 @@ These can be ignored by adding them to the respective baseline file. You can upd
 these files with `make stan-baseline` and `make psalm-baseline`.
 
 ## Release Notes
+
+### Version 2.0.0 - Under development
+
+* Raised the minimum MediaWiki version from 1.39 to 1.43
 
 ### Version 1.0.0 - 2023-11-24
 

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "SPARQL",
 
-	"version": "1.0.0",
+	"version": "2.0.0-dev",
 
 	"author": [
 		"[https://Professional.Wiki/ Professional.Wiki]"
@@ -14,7 +14,7 @@
 	"descriptionmsg": "sparql-description",
 
 	"requires": {
-		"MediaWiki": ">= 1.39.0",
+		"MediaWiki": ">= 1.43.0",
 		"extensions": {
 			"Scribunto": "*"
 		}


### PR DESCRIPTION
For https://github.com/ProfessionalWiki/SPARQL/pull/24#issuecomment-3714642573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.0.0
  * Minimum MediaWiki requirement increased to 1.43 (previously 1.39)

* **Tests**
  * Updated CI infrastructure to support newer MediaWiki versions and PHP 8.5 compatibility

* **Documentation**
  * Updated platform compatibility information in release notes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->